### PR TITLE
Don't show headers on example if there aren't any

### DIFF
--- a/lib/views/example.haml
+++ b/lib/views/example.haml
@@ -85,11 +85,12 @@
     .request{ :id => "request-#{index}" }
       %h3 Request
 
-      %section.headers
-        %h4 Headers
-        %pre.headers
-          :preserve
-            #{request.request_headers}
+      - if request.request_headers.present?
+        %section.headers
+          %h4 Headers
+          %pre.headers
+            :preserve
+              #{request.request_headers}
 
       %section.route
         %h4 Route
@@ -118,11 +119,12 @@
         .response
           %h3 Response
 
-          %section.headers
-            %h4 Headers
-            %pre.headers
-              :preserve
-                #{request.response_headers}
+          - if request.request_headers.present?
+            %section.headers
+              %h4 Headers
+              %pre.headers
+                :preserve
+                  #{request.response_headers}
 
           %section.status
             %h4 Status


### PR DESCRIPTION
This removes a kind of ugly blank gray box under headers if there aren't any to show.
